### PR TITLE
fix missing static

### DIFF
--- a/core/class/netatmoPublicData.class.php
+++ b/core/class/netatmoPublicData.class.php
@@ -139,7 +139,7 @@ class netatmoPublicData extends eqLogic
      *
      * @return array|mixed
      */
-    public function getNetatmoData()
+    public static function getNetatmoData()
     {
 
         $npd_expires_at = config::byKey('npd_expires_at', 'netatmoPublicData');


### PR DESCRIPTION
Prevent error : 
`PHP Fatal error:  Uncaught Error: Non-static method netatmoPublicData::getNetatmoData() cannot be called statically`